### PR TITLE
Format Microdox keymap layers for readability

### DIFF
--- a/config/microdox.keymap
+++ b/config/microdox.keymap
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2020 The ZMK Contributors
  *
@@ -231,55 +230,52 @@
          keymap {
                  compatible = "zmk,keymap";
 
-                 default_layer {
-
-                         bindings = <
-    &kp Q  &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P
-    &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp RET
-    &mt LCTRL Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH
-           &kp LGUI &mo 1 &lt 3 SPACE &td1 &mo 2 &kp LCTRL
-                         >;
-                 };
-                 nav_layer {
- // -----------------------------------------------------------------------------------------
-                         bindings = <
-    &kp HOME   &kp UP       &kp END        &kp RET     &kp KP_PLUS         &kp KP_MULTIPLY    &kp LG(LC(RIGHT))    &kp MINUS      &kp SQT     &kp LC(BSPC)
-    &kp LEFT   &kp DOWN     &kp RIGHT      &kp DEL     &kp EQUAL           &kp LC(LA(TAB))    &kp BSPC             &kp UNDER      &kp DQT     &kp COLON
-    &kp LC(C)  &kp LC(V)    &kp LALT       &kp BSPC    &kp BSLH            &kp PIPE           &kp LG(LC(LEFT))     &kp LT         &kp GT      &kp QMARK
-                             &kp LC(A)    &trans     &kp TILDE          &kp LSHIFT  &kp ESC   &kp GRAVE
-                         >;
-                 };
-
-                 sym_layer {
- // -----------------------------------------------------------------------------------------
-
-                         bindings = <
-    &kp LPAR    &kp LS(LC(HOME))          &trans    &kp LS(LC(END))            &kp EXCL        &kp DOLLAR &kp PRCNT     &kp CARET         &kp 0     &kp RPAR
-    &kp LBRC    &kp LS(LC(LEFT))          &kp KP_N5     &kp LS(LC(RIGHT))          &kp AT          &kp MINUS  &kp TAB       &kp HASH          &kp SEMI       &kp RBRC
-    &kp LBKT    &kp KP_N1                 &kp KP_N2     &kp KP_N3  &kp KP_N0       &kp AMPS   &bt BT_SEL 0  &bt BT_SEL 1      &bt BT_SEL 2   &kp RBKT
-                        &kp LALT  &mo 1 &kp LC(DEL)             &kp LS(FSLH)      &trans         &kp LS(TAB)
-                         >;
-                 };
-
-                 num_layer {
- // -----------------------------------------------------------------------------------------
-
-                         bindings = <
-    &mkp LCLK  &mmv MOVE_UP    &mkp RCLK     &kp LC(LS(F5))      &bt BT_CLR     &msc SCRL_UP   &kp N7  &kp N8 &kp N9 &mkp LCLK
-    &mmv MOVE_LEFT   &mmv MOVE_DOWN  &mmv MOVE_RIGHT      &kp LC(LS(F6))       &msc SCRL_DOWN   &kp PAGE_DOWN   &kp N4  &kp N5 &kp N6 &mkp RCLK
-    &kp LC(Z)        &msc SCRL_LEFT         &msc SCRL_RIGHT     &trans        &trans           &kp N0          &kp N1  &kp N2 &kp N3 &kp BSPC
-                  &trans &trans &kp LOCKING_NUM   &msc SCRL_UP &msc SCRL_DOWN &kp DOT
-                         >;
-                 };
-                 shortcut_layer {
-// -----------------------------------------------------------------------------------------
+                default_layer {
                         bindings = <
- &mkp LCLK        &kp LC(UP)               &mkp RCLK              &kp LC(LS(F5))      &bt BT_CLR          &msc SCRL_UP    &kp N7  &kp N8 &kp N9 &mkp LCLK
- &kp LC(LEFT)     &mmv MOVE_DOWN           &kp LC(RIGHT)          &kp LC(LS(F6))      &msc SCRL_DOWN      &kp PAGE_DOWN   &kp N4  &kp N5 &kp N6 &mkp RCLK
- &kp LC(Z)        &msc SCRL_LEFT           &msc SCRL_RIGHT        &trans              &trans              &kp N0          &kp N1  &kp N2 &kp N3 &kp BSPC
-                  &trans      &trans       &kp LOCKING_NUM                            &kp LG(I)        &msc SCRL_DOWN  &kp DOT
-                 >;
-            };
+    &kp Q          &kp W          &kp E          &kp R          &kp T               &kp Y          &kp U          &kp I          &kp O          &kp P
+    &kp A          &kp S          &kp D          &kp F          &kp G               &kp H          &kp J          &kp K          &kp L          &kp RET
+    &mt LCTRL Z    &kp X          &kp C          &kp V          &kp B               &kp N          &kp M          &kp COMMA      &kp DOT        &kp FSLH
+                                  &kp LGUI       &mo 1          &lt 3 SPACE         &td1           &mo 2          &kp LCTRL
+                        >;
+                };
+                nav_layer {
+                        // -----------------------------------------------------------------------------------------
+                        bindings = <
+    &kp HOME       &kp UP         &kp END        &kp RET        &kp KP_PLUS         &kp KP_MULTIPLY  &kp LG(LC(RIGHT)) &kp MINUS      &kp SQT        &kp LC(BSPC)
+    &kp LEFT       &kp DOWN       &kp RIGHT      &kp DEL        &kp EQUAL           &kp LC(LA(TAB))  &kp BSPC         &kp UNDER      &kp DQT        &kp COLON
+    &kp LC(C)      &kp LC(V)      &kp LALT       &kp BSPC       &kp BSLH            &kp PIPE         &kp LG(LC(LEFT)) &kp LT         &kp GT         &kp QMARK
+                                  &kp LC(A)      &trans         &kp TILDE           &kp LSHIFT       &kp ESC        &kp GRAVE
+                        >;
+                };
+
+                sym_layer {
+                        // -----------------------------------------------------------------------------------------
+                        bindings = <
+    &kp LPAR       &kp LS(LC(HOME)) &trans         &kp LS(LC(END))  &kp EXCL            &kp DOLLAR     &kp PRCNT      &kp CARET      &kp 0          &kp RPAR
+    &kp LBRC       &kp LS(LC(LEFT)) &kp KP_N5      &kp LS(LC(RIGHT))&kp AT              &kp MINUS      &kp TAB        &kp HASH       &kp SEMI       &kp RBRC
+    &kp LBKT       &kp KP_N1        &kp KP_N2      &kp KP_N3        &kp KP_N0           &kp AMPS       &bt BT_SEL 0   &bt BT_SEL 1   &bt BT_SEL 2   &kp RBKT
+                                   &kp LALT       &mo 1            &kp LC(DEL)         &kp LS(FSLH)   &trans         &kp LS(TAB)
+                        >;
+                };
+
+                num_layer {
+                        // -----------------------------------------------------------------------------------------
+                        bindings = <
+    &mkp LCLK      &mmv MOVE_UP   &mkp RCLK      &kp LC(LS(F5)) &bt BT_CLR          &msc SCRL_UP   &kp N7         &kp N8         &kp N9         &mkp LCLK
+    &mmv MOVE_LEFT &mmv MOVE_DOWN &mmv MOVE_RIGHT &kp LC(LS(F6)) &msc SCRL_DOWN       &kp PAGE_DOWN  &kp N4         &kp N5         &kp N6         &mkp RCLK
+    &kp LC(Z)      &msc SCRL_LEFT &msc SCRL_RIGHT &trans         &trans              &kp N0         &kp N1         &kp N2         &kp N3         &kp BSPC
+                                  &trans         &trans         &kp LOCKING_NUM     &msc SCRL_UP   &msc SCRL_DOWN &kp DOT
+                        >;
+                };
+                shortcut_layer {
+                        // -----------------------------------------------------------------------------------------
+                        bindings = <
+    &mkp LCLK      &kp LC(UP)     &mkp RCLK      &kp LC(LS(F5)) &bt BT_CLR          &msc SCRL_UP   &kp N7         &kp N8         &kp N9         &mkp LCLK
+    &kp LC(LEFT)   &mmv MOVE_DOWN &kp LC(RIGHT)  &kp LC(LS(F6)) &msc SCRL_DOWN       &kp PAGE_DOWN  &kp N4         &kp N5         &kp N6         &mkp RCLK
+    &kp LC(Z)      &msc SCRL_LEFT &msc SCRL_RIGHT &trans         &trans              &kp N0         &kp N1         &kp N2         &kp N3         &kp BSPC
+                                  &trans         &trans         &kp LOCKING_NUM     &kp LG(I)      &msc SCRL_DOWN &kp DOT
+                        >;
+                };
          };
  };
 


### PR DESCRIPTION
Reformatted the `bindings` section for the following layers in `config/microdox.keymap` to visually align with the physical layout of the Microdox keyboard (5 columns x 3 rows per hand, plus thumb keys):

- default_layer
- nav_layer
- sym_layer
- num_layer
- shortcut_layer

This change improves the readability and maintainability of the keymap by making the key positions in the configuration file correspond to their physical locations on the keyboard.